### PR TITLE
Add Wartorn Palace to Raids 

### DIFF
--- a/apps/api/src/raidpool/raidpool.service.ts
+++ b/apps/api/src/raidpool/raidpool.service.ts
@@ -13,10 +13,10 @@ export class RaidpoolService {
     private readonly httpService: HttpService,
   ) { }
 
-  private raidpoolCache = new Map<
-    string,
-    { value: { regions: any[]; year: number; week: number }; expiresAt: number }
-  >();
+  // private raidpoolCache = new Map<
+  //   string,
+  //   { value: { regions: any[]; year: number; week: number }; expiresAt: number }
+  // >();
 
   private gambitsCache = new Map<
     string,
@@ -31,24 +31,24 @@ export class RaidpoolService {
 
     const { year, week } = this.getRaidpoolYearWeek(new Date());
     const id = `${year}-${week}`;
-    const now = Date.now();
-    //1 hit cache
-    const cached = this.raidpoolCache.get(id);
-    if (cached && cached.expiresAt > now && cached.value.regions.length === 4) {
-      return cached.value;
-    }
+    // const now = Date.now();
+    // //1 hit cache
+    // const cached = this.raidpoolCache.get(id);
+    // if (cached && cached.expiresAt > now && cached.value.regions.length === 4) {
+    //   return cached.value;
+    // }
 
     //2 db query
-    const existing = await this.raidpoolModel.findOne({ _id: id }).exec();
-    if (existing?.regions?.length === 4) {
-      const value = { regions: existing.regions, year, week };
+    // const existing = await this.raidpoolModel.findOne({ _id: id }).exec();
+    // if (existing?.regions?.length === 4) {
+    //   const value = { regions: existing.regions, year, week };
 
-      this.raidpoolCache.set(id, {
-        value,
-        expiresAt: this.getRaidpoolExpireAt(year, week),
-      });
-      return value;
-    }
+    //   this.raidpoolCache.set(id, {
+    //     value,
+    //     expiresAt: this.getRaidpoolExpireAt(year, week),
+    //   });
+    //   return value;
+    // }
 
     //3 remote fetch
     const response = await this.httpService.axiosRef.get(
@@ -79,10 +79,10 @@ export class RaidpoolService {
 
     const id = `${year}-${week}`;
 
-    const existing = await this.raidpoolModel.findOne({ _id: id }).exec();
-    if (existing?.regions?.length === 4) {
-      return { regions: existing.regions, year, week };
-    }
+    // const existing = await this.raidpoolModel.findOne({ _id: id }).exec();
+    // if (existing?.regions?.length === 4) {
+    //   return { regions: existing.regions, year, week };
+    // }
 
     const response = await this.httpService.axiosRef.get(
       `https://www.wynnventory.com/api/raidpool/${year}/${week}`,
@@ -116,7 +116,7 @@ export class RaidpoolService {
     const now = Date.now();
     const { year, month, day, key } = this.getGambitsDateKey(new Date());
 
-    //1 hit cache
+    // //1 hit cache
     const cached = this.gambitsCache.get(key);
     if (cached && cached.expiresAt > now && cached.value.gambits?.length === 4) {
       return cached.value;

--- a/apps/web/src/app/raid/_component/class-aspect-finder.tsx
+++ b/apps/web/src/app/raid/_component/class-aspect-finder.tsx
@@ -19,18 +19,19 @@ interface Region {
 }
 
 type Category = "aspect" | "tome" | "gear" | "misc"
-type RegionAbbrev = "NOTG" | "NOL" | "TCC" | "TNA"
-type RegionName = "Nest of the Grootslangs" | "Orphion's Nexus of Light" | "The Canyon Colossus" | "The Nameless Anomaly"
+type RegionAbbrev = "NOTG" | "NOL" | "TCC" | "TNA" | "TWP"
+type RegionName = "Nest of the Grootslangs" | "Orphion's Nexus of Light" | "The Canyon Colossus" | "The Nameless Anomaly" | "The Wartorn Palace"
 type ClassId = "Archer" | "Mage" | "Warrior" | "Assassin" | "Shaman"
 type GroupBy = "rarity" | "region"
 
-const REGION_ABBREV_ORDER: readonly RegionAbbrev[] = ["NOTG", "NOL", "TCC", "TNA"] as const
+const REGION_ABBREV_ORDER: readonly RegionAbbrev[] = ["NOTG", "NOL", "TCC", "TNA", "TWP"] as const
 
 const REGION_LABELS: Record<RegionAbbrev, RegionName> = {
     NOTG: "Nest of the Grootslangs",
     NOL: "Orphion's Nexus of Light",
     TCC: "The Canyon Colossus",
     TNA: "The Nameless Anomaly",
+    TWP: "The Wartorn Palace"
 } as const
 
 const CLASSES = [

--- a/apps/web/src/app/raid/_component/loot-display.tsx
+++ b/apps/web/src/app/raid/_component/loot-display.tsx
@@ -20,8 +20,8 @@ export interface LootData {
 }
 
 type Category = "aspect" | "tome" | "gear" | "misc"
-type RegionAbbrev = "NOTG" | "NOL" | "TCC" | "TNA"
-type RegionName = "Nest of the Grootslangs" | "Orphion's Nexus of Light" | "The Canyon Colossus" | "The Nameless Anomaly"
+type RegionAbbrev = "NOTG" | "NOL" | "TCC" | "TNA" | "TWP"
+type RegionName = "Nest of the Grootslangs" | "Orphion's Nexus of Light" | "The Canyon Colossus" | "The Nameless Anomaly" | "The Wartorn Palace"
 
 // Constants
 const CATEGORIES: readonly Category[] = ["aspect", "tome", "gear", "misc"] as const
@@ -32,13 +32,14 @@ const RARITY_RANK = Object.fromEntries(
     RARITY_ORDER.map((r, i) => [r.toLowerCase(), i])
 )
 
-const REGION_ABBREV_ORDER: readonly RegionAbbrev[] = ["NOTG", "NOL", "TCC", "TNA"] as const
+const REGION_ABBREV_ORDER: readonly RegionAbbrev[] = ["NOTG", "NOL", "TCC", "TNA", "TWP"] as const
 
 const REGION_LABELS: Record<RegionAbbrev, RegionName> = {
     NOTG: "Nest of the Grootslangs",
     NOL: "Orphion's Nexus of Light",
     TCC: "The Canyon Colossus",
     TNA: "The Nameless Anomaly",
+    TWP: "The Wartorn Palace"
 } as const
 
 // Type Guards & Helpers


### PR DESCRIPTION
Not sure if this is how you add it, but I tried. Don't have an API key to test with either. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "The Wartorn Palace" (TWP) region to raid filtering, sorting, and labels.
* **Chores**
  * Updated raidpool retrieval behavior; you may notice differences in data load timings or availability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->